### PR TITLE
fix: discounted amt should be in negative in order preview

### DIFF
--- a/src/components/modals/modalCreateSub.tsx
+++ b/src/components/modals/modalCreateSub.tsx
@@ -641,7 +641,7 @@ const Index = ({
                   <Col
                     className=" text-gray-800"
                     span={8}
-                  >{`${showAmount(preview.discountAmount, preview.currency)}`}</Col>
+                  >{`${showAmount(preview.discountAmount * -1, preview.currency)}`}</Col>
                 </Row>
                 <Row>
                   <Col


### PR DESCRIPTION
<!--
Before submitting this pull request:

- Make sure you have read the [contributing guidelines](#)
- It should pass all tests in the available GitHub actions
- You should add/modify tests to cover your proposed code changes
- If your pull request contains a new feature, please document it on the README
-->

## Summary of changes
- discounted amt should be in negative value in Order Preview modal

## Other information
<!-- Other useful information -->
