### PR TITLE
style: adjust long planName/Desc using popover component

### DIFF
--- a/src/components/plans/plan.tsx
+++ b/src/components/plans/plan.tsx
@@ -3,6 +3,7 @@ import type { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useEffect, useState } from 'react'
 import { formatPlanPrice, showAmount } from '../../helpers'
 import { IPlan } from '../../shared.types'
+import LongTextPopover from '../ui/longTextPopover'
 import { SubscriptionStatus } from '../ui/statusTag'
 
 interface IPLanProps {
@@ -143,8 +144,12 @@ const Index = ({
               : 'unset'
         }}
       >
-        <div style={{ fontSize: '28px' }}>{plan.planName}</div>
-        <div>{plan.description}</div>
+        <div style={{ fontSize: '28px' }}>
+          <LongTextPopover text={plan.planName} width="230px" />
+        </div>
+        <div>
+          <LongTextPopover text={plan.description} width="240px" />
+        </div>
 
         {hasAddonInfo && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>

--- a/src/components/profile/onetimeHistory.tsx
+++ b/src/components/profile/onetimeHistory.tsx
@@ -7,6 +7,7 @@ import { formatDate } from '../../helpers'
 import { getOnetimePaymentHistoryReq } from '../../requests'
 import { IOneTimeHistoryItem } from '../../shared.types'
 import { usePagination } from '../hooks'
+import LongTextPopover from '../ui/longTextPopover'
 import { PaymentStatus } from '../ui/statusTag'
 
 const PAGE_SIZE = 10
@@ -40,7 +41,12 @@ const Index = () => {
     {
       title: 'Item Name',
       dataIndex: 'name',
-      key: 'name'
+      key: 'name',
+      width: 180,
+      render: (_, record) =>
+        record.name == null ? null : (
+          <LongTextPopover text={record.name} width="180px" />
+        )
     },
     {
       title: 'Purchase Time',

--- a/src/components/profile/subHistory.tsx
+++ b/src/components/profile/subHistory.tsx
@@ -8,6 +8,7 @@ import { getProductListReq, getSubHistoryReq } from '../../requests'
 import { usePagination } from '../hooks'
 
 import { IProduct, ISubAddon, ISubHistoryItem } from '../../shared.types.ts'
+import LongTextPopover from '../ui/longTextPopover.tsx'
 import { SubHistoryStatus } from '../ui/statusTag.tsx'
 // import { SubscriptionStatus } from '../ui/statusTag';
 
@@ -38,7 +39,10 @@ const Index = () => {
       dataIndex: 'itemName',
       key: 'itemName',
       width: 180,
-      render: (_, record) => (record.plan == null ? null : record.plan.planName)
+      render: (_, record) =>
+        record.plan == null ? null : (
+          <LongTextPopover text={record.plan.planName} width="180px" />
+        )
     },
     {
       title: 'Start Time',

--- a/src/components/profile/subscription.tsx
+++ b/src/components/profile/subscription.tsx
@@ -27,6 +27,7 @@ import { DiscountCode, ISubscription } from '../../shared.types'
 import { useAppConfigStore } from '../../stores'
 import CancelSubModal from '../modals/modalCancelPendingSub'
 import ModalResumeOrTerminateSub from '../modals/modalTerminateOrResumeSub'
+import LongTextPopover from '../ui/longTextPopover'
 import { DiscountCodeStatus, SubscriptionStatus } from '../ui/statusTag'
 
 const APP_PATH = import.meta.env.BASE_URL // default is / (if no --base specified in build cmd)
@@ -125,11 +126,21 @@ const PendingUpdateSection = ({ subInfo }: { subInfo: ISubscription }) => {
         <Col span={4} style={colStyle}>
           Plan
         </Col>
-        <Col span={6}>{i!.updatePlan.planName}</Col>
+        <Col span={6}>
+          <LongTextPopover
+            text={i!.updatePlan.planName}
+            showViewMoreButton={true}
+          />
+        </Col>
         <Col span={4} style={colStyle}>
           Plan Description
         </Col>
-        <Col span={6}>{i!.updatePlan.description}</Col>
+        <Col span={10}>
+          <LongTextPopover
+            text={i!.updatePlan.description}
+            showViewMoreButton={true}
+          />
+        </Col>
       </Row>
 
       <Row style={rowStyle}>
@@ -294,11 +305,22 @@ const SubscriptionInfoSection = ({ subInfo, refresh }: ISubSectionProps) => {
         <Col span={4} style={colStyle}>
           Plan
         </Col>
-        <Col span={6}>{subInfo?.plan?.planName}</Col>
+        <Col span={6}>
+          <LongTextPopover
+            text={subInfo?.plan?.planName}
+            showViewMoreButton={true}
+          />
+        </Col>
         <Col span={4} style={colStyle}>
           Plan Description
         </Col>
-        <Col span={6}>{subInfo?.plan?.description}</Col>
+        <Col span={10}>
+          {' '}
+          <LongTextPopover
+            text={subInfo?.plan?.description}
+            showViewMoreButton={true}
+          />
+        </Col>
       </Row>
       <Row style={rowStyle}>
         <Col span={4} style={colStyle}>

--- a/src/components/ui/longTextPopover.tsx
+++ b/src/components/ui/longTextPopover.tsx
@@ -1,0 +1,99 @@
+import { Button, Popover } from 'antd'
+import { TooltipPlacement } from 'antd/es/tooltip'
+import { useEffect, useRef, useState } from 'react'
+
+const Index = ({
+  text,
+  width,
+  showViewMoreButton, // true: there is a 'View more' button to the right of the text, hover to show popup, false: no button, just hover on text to show popup
+  // the latter case is mostly used in table column with limited width
+  placement,
+  clickHandler
+}: {
+  text: string
+  width?: string // must be of format: '128px'
+  showViewMoreButton?: boolean
+  placement?: TooltipPlacement
+  clickHandler?: () => void
+}) => {
+  const [showMore, setShowMore] = useState<boolean>(false)
+  const textRef = useRef<HTMLDivElement>(null)
+  const textContent =
+    clickHandler == undefined ? (
+      text
+    ) : (
+      <span className="cursor-pointer text-blue-400" onClick={clickHandler}>
+        {text}
+      </span>
+    )
+
+  const renderPopup = () =>
+    showViewMoreButton ? (
+      <>
+        <div
+          className="overflow-hidden text-ellipsis whitespace-nowrap"
+          ref={textRef}
+          style={{
+            maxWidth: width ?? `calc(100% - ${showMore ? '80px' : '0px'})` // 'view more' button was around 80px width(plus some padding/margin)
+          }}
+        >
+          {textContent}
+        </div>
+        {showMore && (
+          <PopoverWrapper placement={placement} text={text}>
+            <Button
+              type="link"
+              style={{ border: 'none', padding: '0', marginRight: '8px' }}
+            >
+              View more
+            </Button>
+          </PopoverWrapper>
+        )}
+      </>
+    ) : (
+      <div
+        className="overflow-hidden text-ellipsis whitespace-nowrap"
+        ref={textRef}
+        style={{
+          maxWidth: width ?? '100%'
+        }}
+      >
+        {showMore ? (
+          <PopoverWrapper placement={placement} text={text}>
+            {textContent}
+          </PopoverWrapper>
+        ) : (
+          textContent
+        )}
+      </div>
+    )
+
+  useEffect(() => {
+    if (textRef.current) {
+      const { current } = textRef
+      if (current.scrollWidth > current.clientWidth) {
+        setShowMore(true)
+      } else {
+        setShowMore(false)
+      }
+    }
+  }, [textRef])
+
+  return <div className="flex items-center">{renderPopup()}</div>
+}
+
+export default Index
+
+const PopoverWrapper = ({
+  text,
+  placement,
+  children
+}: React.PropsWithChildren<{ text: string; placement?: TooltipPlacement }>) => (
+  <Popover
+    placement={placement ?? 'topLeft'}
+    overlayStyle={{ width: '360px' }}
+    content={text}
+  >
+    {children}
+  </Popover>
+)


### PR DESCRIPTION
<!--
Before submitting this pull request:

- Make sure you have read the [contributing guidelines](#)
- It should pass all tests in the available GitHub actions
- You should add/modify tests to cover your proposed code changes
- If your pull request contains a new feature, please document it on the README
-->

## Summary of changes
- style: long plan name/description now have a popover to show full content

## Other information
<!-- Other useful information -->
