### PR TITLE
fix: pass stripeId when calling remove payment-method

### DIFF
--- a/src/components/profile/editCard.tsx
+++ b/src/components/profile/editCard.tsx
@@ -94,6 +94,7 @@ const Index = ({ defaultPaymentId, refresh }: Props) => {
   const removeCard = async (paymentMethodId: string) => {
     setLoading(true)
     const [_, err] = await removePaymentMethodReq({
+      gatewayId: stripeGatewayId!,
       paymentMethodId
     })
     if (null != err) {

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -1,11 +1,10 @@
 import axios from 'axios'
 import update from 'immutability-helper'
 import { ExpiredError, IProfile } from '../shared.types'
-import { useAppConfigStore, useProfileStore, useSessionStore } from '../stores'
+import { useProfileStore, useSessionStore } from '../stores'
 import { request } from './client'
 
 const session = useSessionStore.getState()
-const appConfig = useAppConfigStore.getState()
 
 const updateSessionCb = (refreshCb?: () => void) => {
   const refreshCallbacks = update(session.refreshCallbacks, {
@@ -850,38 +849,15 @@ export const addPaymentMethodReq = async ({
 }
 
 export const removePaymentMethodReq = async ({
+  gatewayId,
   paymentMethodId
 }: {
+  gatewayId: number
   paymentMethodId: string
 }) => {
-  const stripeGatewayId = appConfig.gateway.find(
-    (g) => g.gatewayName == 'stripe'
-  )?.gatewayId
-  const body = { gatewayId: stripeGatewayId, paymentMethodId }
+  const body = { gatewayId, paymentMethodId }
   try {
     const res = await request.post('/user/payment/method_delete', body)
-    handleStatusCode(res.data.code)
-    return [res.data.data, null]
-  } catch (err) {
-    const e = err instanceof Error ? err : new Error('Unknown error')
-    return [null, e]
-  }
-}
-
-// change the current subscription's payment method
-export const changePaymentMethodReq = async ({
-  paymentMethodId,
-  subscriptionId
-}: {
-  paymentMethodId: string
-  subscriptionId: string
-}) => {
-  const stripeGatewayId = appConfig.gateway.find(
-    (g) => g.gatewayName == 'stripe'
-  )?.gatewayId
-  const body = { paymentMethodId, subscriptionId, gatewayId: stripeGatewayId }
-  try {
-    const res = await request.post('/user/subscription/change_gateway', body)
     handleStatusCode(res.data.code)
     return [res.data.data, null]
   } catch (err) {


### PR DESCRIPTION
<!--
Before submitting this pull request:

- Make sure you have read the [contributing guidelines](#)
- It should pass all tests in the available GitHub actions
- You should add/modify tests to cover your proposed code changes
- If your pull request contains a new feature, please document it on the README
-->

## Summary of changes:
- fix: pass stripeId when removing a payment method from caller, instead of getting id inside callee. Becuase this id could be undefined inside callee

## Other information
<!-- Other useful information -->
